### PR TITLE
Fix multiple browser tabs on Skype link click

### DIFF
--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -109,6 +109,11 @@ Ext.define('Rambox.ux.WebView',{
 
 		// Open links in default browser
 		webview.addEventListener('new-window', function(e) {
+			// hack to fix multiple browser tabs on Skype link click, re #11
+			if (e.url === 'https://web.skype.com/en/undefined') {
+				console.log(e);
+				return;
+			}
 			const protocol = require('url').parse(e.url).protocol;
 			if (protocol === 'http:' || protocol === 'https:' || protocol === 'mailto:') {
 				e.preventDefault();


### PR DESCRIPTION
Rather nasty hack, but prevents opening many tabs in browser after clicking a link in Skype.
There seem to be invalid events generated, so log them in console for further inspection.

Fixes #11 and also fixes #102 duplicate I've reported.