### PR TITLE
Add rpm to Linux build outputs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
       sudo apt-get update -qq;
       sudo apt-get install -qq libxml2-dev;
       sudo apt-get install -qq libappindicator1;
+      sudo apt-get install -qq rpm;
     fi
 install:
   - git config --global core.autocrlf input

--- a/package.json
+++ b/package.json
@@ -90,13 +90,10 @@
 		"linux": {
 			"target": [
 				"AppImage",
-				"deb",
+			        "deb",
+                                "rpm",
 				"zip",
 				"tar.gz"
-			],
-			"depends": [
-				"libappindicator1",
-				"libnotify-bin"
 			],
 			"icon": "./resources/Icon.png"
 		}


### PR DESCRIPTION
Hi @saenzramiro! Thanks so much for creating Rambox – so far I was using the gzipped version, but I would love to just install & update it via RPM. I only had to add one output type and remove the `depends` option, as electron builder will use defaults (see electron-userland/electron-builder#502) if you don't specify them (and the package names are probably different anyways for RPM based distributions).

All in all it seems to work pretty well (on Fedora 24, that is):
![screenshot from 2016-08-11 23-04-18](https://cloud.githubusercontent.com/assets/51264/17605120/1decaeae-6019-11e6-82e6-4f3e9e40391d.png)