### PR TITLE
Improve Slack Message Counting

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -36,7 +36,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,description: 'Slack brings all your communication together in one place. It’s real-time messaging, archiving and search for modern teams.'
 			,url: 'https://___.slack.com/'
 			,type: 'messaging'
-			,js_unread: 'function checkUnread(){var t=0;$(".unread_msgs").each(function() { t += parseInt($(this).html()) });$("#im-list .unread_highlights").each(function() { t += parseInt($(this).html()) });updateBadge(t)}function updateBadge(e){e>=1?document.title="("+e+") "+originalTitle:document.title=originalTitle}var originalTitle=document.title;setInterval(checkUnread,3000);'
+			,js_unread: 'function checkUnread(){var a=0,b=0;$(".unread_msgs").each(function(){a+=parseInt($(this).html())}),$(".unread_highlights").each(function(){b+=parseInt($(this).html())}),updateBadge(a,b)}function updateBadge(a,b){var c=b>0?"("+b+") ":a>0?"(•) ":"";document.title=c.originalTitle}var originalTitle=document.title;setInterval(checkUnread,3000);'
 		},
 		{
 			 id: 'noysi'


### PR DESCRIPTION
This takes care of the slack counting problem, but this still doesn't fix the entire problem:

https://github.com/saenzramiro/rambox/blob/master/app/ux/WebView.js#L173-L178

Currently Rambox only accepts numbers on the notification badge, but on slack case if we need to allow `•`, how do you suggest to do this change?