### PR TITLE
Improves main window close handling on linux

### DIFF
--- a/electron/global_settings.js
+++ b/electron/global_settings.js
@@ -26,6 +26,11 @@ var globalSettings = {
 	}
 };
 
+if (process.platform === 'linux') {
+	// default setting for linux: exit app on close
+	globalSettings.settings.keep_in_taskbar_on_close = 0;
+}
+
 try {
 	//test to see if settings exist
 	fs.openSync(settingsPathname, 'r+'); //throws error if file doesn't exist

--- a/electron/main.js
+++ b/electron/main.js
@@ -155,6 +155,19 @@ function createWindow () {
 		if ( !isQuitting ) {
 			e.preventDefault();
 
+			switch (process.platform) {
+				case 'darwin':
+					app.hide();
+					break;
+				case 'linux':
+					parseInt(globalSettings.get('keep_in_taskbar_on_close')) ? mainWindow.hide() : app.quit();
+					break;
+				case 'win32':
+				default:
+					parseInt(globalSettings.get('keep_in_taskbar_on_close')) ? mainWindow.minimize() : mainWindow.hide();
+					break;
+			}
+
 			if (process.platform === 'darwin') {
 				app.hide();
 			} else {


### PR DESCRIPTION
• Per default apps are quit when you close them on linux → changed default setting for keep in taskbar on linux
• Changed main window close handling for linux: exit app when keep in taskbar is disabled

Should fix #162 and #166