### PR TITLE
Improves main window close handling on linux

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -24,7 +24,7 @@ const config = new Config({
 		,hide_menu_bar: false
 		,skip_taskbar: true
 		,auto_launch: !isDev
-		,keep_in_taskbar_on_close: true
+		,keep_in_taskbar_on_close: getDefaultValueForkeep_in_taskbar_on_close()
 		,start_minimized: false
 		,systemtray_indicator: true
 		,master_password: false
@@ -39,6 +39,15 @@ const config = new Config({
 		,maximized: false
 	}
 });
+
+/**
+ * Returns the default value for "keep_in_taskbar_on_close".
+ * On all platforms except linux: true
+ * On linux: false (because it's uncommon for apps on linux to stay in the taskbar on close)
+ */
+function getDefaultValueForkeep_in_taskbar_on_close() {
+	return process.platform !== 'linux';
+}
 
 // Configure AutoLaunch
 const appLauncher = new AutoLaunch({

--- a/electron/main.js
+++ b/electron/main.js
@@ -201,10 +201,17 @@ function createWindow () {
 		if ( !isQuitting ) {
 			e.preventDefault();
 
-			if (process.platform === 'darwin') {
-				app.hide();
-			} else {
-				config.get('keep_in_taskbar_on_close') ? mainWindow.minimize() : mainWindow.hide();
+			switch (process.platform) {
+				case 'darwin':
+					app.hide();
+					break;
+				case 'linux':
+					config.get('keep_in_taskbar_on_close') ? mainWindow.hide() : app.quit();
+					break;
+				case 'win32':
+				default:
+					config.get('keep_in_taskbar_on_close') ? mainWindow.minimize() : mainWindow.hide();
+					break;
 			}
 		}
 	});


### PR DESCRIPTION
* Sets the default for "keep_in_taskbar_on_close" on linux to false (because it's uncommon)
* Updates close handling for linux:
 * If "keep_in_taskbar_on_close" is true hide the main window. Rambox then still appears in the "panale" of the desktop environment.
 * Else exit the app

Should fix #166