### PR TITLE
[Fix] sets a mac-friendly name for auto-launch

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -44,7 +44,7 @@ const config = new Config({
 
 // Configure AutoLaunch
 const appLauncher = new AutoLaunch({
-	 name: 'Rambox'
+	 name: 'Rambox.app'
 	,isHiddenOnLaunch: config.get('start_minimized')
 });
 config.get('auto_launch') && !isDev ? appLauncher.enable() : appLauncher.disable();


### PR DESCRIPTION
This should have Rambox set the Mac app (vs its internal binary) as a login item.

It will not remove the `Rambox` entry which was already in place.

Fixes #411 but only for future installs