### PR TITLE
simplify automatic start option's wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@
 - [x] Mute audio to specific service.
 - [x] Separate tabs floating to the right.
 - [x] Go Offline on specific service.
-- [x] Start automatically on system startup.
+- [x] Start automatically.
 - [x] Custom Code Injection.
 - [x] Keyboard Shortcuts.
 - [x] Proxy.

--- a/app/view/preferences/Preferences.js
+++ b/app/view/preferences/Preferences.js
@@ -45,7 +45,7 @@ Ext.define('Rambox.view.preferences.Preferences',{
 					{
 						 xtype: 'checkbox'
 						,name: 'auto_launch'
-						,boxLabel: 'Start automatically on system startup'
+						,boxLabel: 'Start automatically'
 						,value: config.auto_launch
 					}
 					,{


### PR DESCRIPTION
Per the conversation about auto-login in https://github.com/saenzramiro/rambox/issues/411#issuecomment-259446777 

The phrase `on system startup` is not accurate. If `on login` is too detailed, I suggest removing when, and let people assume the best.
