### PR TITLE
remove extra space before service name

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -459,7 +459,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,type: 'email'
 		},
 		{
-			 id: ' irccloud'
+			 id: 'irccloud'
 			,logo: 'irccloud.png'
 			,name: 'IRCCloud'
 			,description: 'IRCCloud is a modern IRC client that keeps you connected, with none of the baggage.'


### PR DESCRIPTION
`id: ' irccloud'` => ` id: 'irccloud'`