### PR TITLE
Adds options to disable a service unread count per tab and globally

### DIFF
--- a/app/model/Service.js
+++ b/app/model/Service.js
@@ -37,7 +37,18 @@ Ext.define('Rambox.model.Service', {
 		 name: 'muted'
 		,type: 'boolean'
 		,defaultValue: false
-	},{
+	},
+	{
+		name: 'displayTabUnreadCounter',
+		type: 'boolean',
+		defaultValue: true
+	},
+	{
+		name: 'includeInGlobalUnreadCounter',
+		type: 'boolean',
+		defaultValue: true
+	},
+	{
 		 name: 'trust'
 		,type: 'boolean'
 		,defaultValue: false

--- a/app/store/Services.js
+++ b/app/store/Services.js
@@ -33,8 +33,10 @@ Ext.define('Rambox.store.Services', {
 					,icon: service.get('type') !== 'custom' ? 'resources/icons/'+service.get('logo') : ( service.get('logo') === '' ? 'resources/icons/custom.png' : service.get('logo'))
 					,src: service.get('url')
 					,type: service.get('type')
-					,muted: service.get('muted')
-					,enabled: service.get('enabled')
+					,muted: service.get('muted'),
+					includeInGlobalUnreadCounter: service.get('includeInGlobalUnreadCounter'),
+					displayTabUnreadCounter: service.get('displayTabUnreadCounter'),
+					enabled: service.get('enabled')
 					,record: service
 					,tabConfig: {
 						service: service

--- a/app/util/Notifier.js
+++ b/app/util/Notifier.js
@@ -1,0 +1,57 @@
+
+/**
+ * Singleton class for notification dispatching.
+ */
+Ext.define('Rambox.util.Notifier', {
+
+	singleton: true,
+
+	constructor: function(config) {
+
+		config = config || {};
+
+		/**
+		 * Returns the notification text depending on the service type.
+		 *
+		 * @param view
+		 * @param count
+		 * @return {*}
+		 */
+		function getNotificationText(view, count) {
+			var text;
+			switch (Ext.getStore('ServicesList').getById(view.type).get('type')) {
+				case 'messaging':
+					text = 'You have ' + Ext.util.Format.plural(count, 'new message', 'new messages') + '.';
+					break;
+				case 'email':
+					text = 'You have ' + Ext.util.Format.plural(count, 'new email', 'new emails') + '.';
+					break;
+				default:
+					text = 'You have ' + Ext.util.Format.plural(count, 'new activity', 'new activities') + '.';
+					break;
+			}
+			return text;
+		}
+
+		/**
+		 * Dispatches a notification for a specific service.
+		 *
+		 * @param view				The view of the service
+		 * @param {number} count	The unread count
+		 */
+		this.dispatchNotification = function(view, count) {
+			var text = getNotificationText(view, count);
+
+			var notification = new Notification(view.record.get('name'), {
+				body: text,
+				icon: view.tab.icon,
+				silent: view.record.get('muted')
+			});
+
+			notification.onclick = function() {
+				require('electron').remote.getCurrentWindow().show();
+				Ext.cq1('app-main').setActiveTab(view);
+			};
+		}
+	}
+});

--- a/app/util/UnreadCounter.js
+++ b/app/util/UnreadCounter.js
@@ -1,0 +1,76 @@
+/**
+ * Singleton class to handle the global unread counter.
+ */
+Ext.define('Rambox.util.UnreadCounter', {
+
+	singleton: true,
+
+	constructor: function(config) {
+
+		config = config || {};
+
+		/**
+		 * Map for storing the global unread count.
+		 * service id -> unread count
+		 *
+		 * @type {Map}
+		 */
+		var unreadCountByService = new Map();
+
+		/**
+		 * Holds the global unread count for internal usage.
+		 *
+		 * @type {number}
+		 */
+		var totalUnreadCount = 0;
+
+		/**
+		 * Sets the application's unread count to tracked unread count.
+		 */
+		function updateAppUnreadCounter() {
+			Rambox.app.setTotalNotifications(totalUnreadCount);
+		}
+
+		/**
+		 * Returns the global unread count.
+		 *
+		 * @return {number}
+		 */
+		this.getTotalUnreadCount = function() {
+			return totalUnreadCount;
+		};
+
+		/**
+		 * Sets the global unread count for a specific service.
+		 *
+		 * @param {*} id				Id of the service to set the global unread count for.
+		 * @param {number} unreadCount	The global unread count for the service.
+		 */
+		this.setUnreadCountForService = function(id, unreadCount) {
+			unreadCount = parseInt(unreadCount, 10);
+
+			console.log('Rambox.util.UnreadCounter#setUnreadCountForService(' + id + ', ' + unreadCount + ')');
+			if (unreadCountByService.has(id)) {
+				totalUnreadCount -= unreadCountByService.get(id);
+			}
+			totalUnreadCount += unreadCount;
+			unreadCountByService.set(id, unreadCount);
+
+			updateAppUnreadCounter();
+		};
+
+		/**
+		 * Clears the global unread count for a specific service.
+		 *
+		 * @param {*} id	Id of the service to clear the global unread count for.
+		 */
+		this.clearUnreadCountForService = function(id) {
+			if (unreadCountByService.has(id)) {
+				totalUnreadCount -= unreadCountByService.get(id);
+			}
+			unreadCountByService['delete'](id);
+
+			updateAppUnreadCounter();
+		}
+	}
+});

--- a/app/util/UnreadCounter.js
+++ b/app/util/UnreadCounter.js
@@ -49,7 +49,6 @@ Ext.define('Rambox.util.UnreadCounter', {
 		this.setUnreadCountForService = function(id, unreadCount) {
 			unreadCount = parseInt(unreadCount, 10);
 
-			console.log('Rambox.util.UnreadCounter#setUnreadCountForService(' + id + ', ' + unreadCount + ')');
 			if (unreadCountByService.has(id)) {
 				totalUnreadCount -= unreadCountByService.get(id);
 			}

--- a/app/view/add/Add.js
+++ b/app/view/add/Add.js
@@ -162,8 +162,31 @@ Ext.define('Rambox.view.add.Add',{
 								,inputValue: true
 							}
 						]
-					}
-					,{
+					},
+					{
+						xtype: 'fieldset',
+						title: 'Unread counter',
+						margin: '10 0 0 0',
+						items: [
+							{
+								xtype: 'checkbox',
+								boxLabel: 'Display tab unread counter',
+								name: 'displayTabUnreadCounter',
+								checked: me.edit ? me.record.get('displayTabUnreadCounter') : true,
+								uncheckedValue: false,
+								inputValue: true
+							},
+							{
+								xtype: 'checkbox',
+								boxLabel: 'Include in global unread counter',
+								name: 'includeInGlobalUnreadCounter',
+								checked: me.edit ? me.record.get('includeInGlobalUnreadCounter') : true,
+								uncheckedValue: false,
+								inputValue: true
+							}
+						]
+					},
+					{
 						 xtype: 'fieldset'
 						,title: 'Advanced'
 						,margin: '10 0 0 0'

--- a/app/view/add/AddController.js
+++ b/app/view/add/AddController.js
@@ -1,8 +1,12 @@
 Ext.define('Rambox.view.add.AddController', {
-	 extend: 'Ext.app.ViewController'
-	,alias: 'controller.add-add'
+	extend: 'Ext.app.ViewController',
+	alias: 'controller.add-add',
 
-	,doCancel: function( btn ) {
+	requires: [
+		'Rambox.util.UnreadCounter'
+	],
+
+	doCancel: function( btn ) {
 		var me = this;
 
 		me.getView().close();
@@ -29,37 +33,44 @@ Ext.define('Rambox.view.add.AddController', {
 				,url: formValues.url
 				,align: formValues.align
 				,notifications: formValues.notifications
-				,muted: formValues.muted
-				,trust: formValues.trust
+				,muted: formValues.muted,
+				displayTabUnreadCounter: formValues.displayTabUnreadCounter,
+				includeInGlobalUnreadCounter: formValues.includeInGlobalUnreadCounter,
+				trust: formValues.trust
 				,js_unread: formValues.js_unread
 			});
+
+			var view = Ext.getCmp('tab_'+win.record.get('id'));
+
 			// Change the title of the Tab
-			Ext.getCmp('tab_'+win.record.get('id')).setTitle(formValues.serviceName);
+			view.setTitle(formValues.serviceName);
 			// Change sound of the Tab
-			Ext.getCmp('tab_'+win.record.get('id')).setAudioMuted(formValues.muted);
+			view.setAudioMuted(formValues.muted);
 			// Change notifications of the Tab
-			Ext.getCmp('tab_'+win.record.get('id')).setNotifications(formValues.notifications);
+			view.setNotifications(formValues.notifications);
 			// Change the icon of the Tab
 			if ( win.record.get('type') === 'custom' && oldData.logo !== formValues.logo ) Ext.getCmp('tab_'+win.record.get('id')).setConfig('icon', formValues.logo === '' ? 'resources/icons/custom.png' : formValues.logo);
 			// Change the URL of the Tab
-			if ( oldData.url !== formValues.url ) Ext.getCmp('tab_'+win.record.get('id')).setURL(formValues.url);
+			if ( oldData.url !== formValues.url ) view.setURL(formValues.url);
 			// Change the align of the Tab
 			if ( oldData.align !== formValues.align ) {
 				if ( formValues.align === 'left' ) {
-					Ext.cq1('app-main').moveBefore(Ext.getCmp('tab_'+win.record.get('id')), Ext.getCmp('tbfill'));
+					Ext.cq1('app-main').moveBefore(view, Ext.getCmp('tbfill'));
 				} else {
-					Ext.cq1('app-main').moveAfter(Ext.getCmp('tab_'+win.record.get('id')), Ext.getCmp('tbfill'));
+					Ext.cq1('app-main').moveAfter(view, Ext.getCmp('tbfill'));
 				}
 			}
 			// Apply the JS Code of the Tab
 			if ( win.down('textarea').isDirty() ) {
 				Ext.Msg.confirm('CUSTOM CODE', 'Rambox needs to reload the service to execute the new JavaScript code. Do you want to do it now?', function( btnId ) {
-					if ( btnId === 'yes' ) Ext.getCmp('tab_'+win.record.get('id')).reloadService();
+					if ( btnId === 'yes' ) view.reloadService();
 				});
 			}
 
-			Ext.getCmp('tab_'+win.record.get('id')).record = win.record;
-			Ext.getCmp('tab_'+win.record.get('id')).tabConfig.service = win.record;
+			view.record = win.record;
+			view.tabConfig.service = win.record;
+
+			view.refreshUnreadCount();
 		} else {
 			// Format data
 			if ( win.record.get('url').indexOf('___') >= 0 ) {
@@ -73,8 +84,10 @@ Ext.define('Rambox.view.add.AddController', {
 				,url: formValues.url
 				,align: formValues.align
 				,notifications: formValues.notifications
-				,muted: formValues.muted
-				,trust: formValues.trust
+				,muted: formValues.muted,
+				displayTabUnreadCounter: formValues.displayTabUnreadCounter,
+				includeInGlobalUnreadCounter: formValues.includeInGlobalUnreadCounter,
+				trust: formValues.trust
 				,js_unread: formValues.js_unread
 			});
 			service.save();
@@ -121,5 +134,4 @@ Ext.define('Rambox.view.add.AddController', {
 		// Make focus to the name field
 		win.down('textfield[name="serviceName"]').focus(true, 100);
 	}
-
 });


### PR DESCRIPTION
Adds two options per service:
- disable the unread count for a tab (but still add to the global count)
- exclude the unread count of a service for the global count

Includes some refactorings:
- extracts the notification dispatching to "Rambox.util.Notifier"
- extracts the unread count tracking to "Rambox.util.UnreadCounte"

Should solve #187 