### PR TITLE
Adds an option to control the behavior on closing the main window

### DIFF
--- a/app/view/preferences/Preferences.js
+++ b/app/view/preferences/Preferences.js
@@ -67,17 +67,28 @@ Ext.define('Rambox.view.preferences.Preferences',{
 						,boxLabel: 'Show in Taskbar'
 						,value: config.skip_taskbar
 						,reference: 'skipTaskbar'
-						,hidden: process.platform !== 'win32'
-					}
-					,{
-						 xtype: 'checkbox'
-						,name: 'keep_in_taskbar_on_close'
-						,boxLabel: 'Keep Rambox in the Taskbar when close it'
-						,value: config.keep_in_taskbar_on_close
-						,bind: { disabled: '{!skipTaskbar.checked}' }
-						,hidden: process.platform !== 'win32'
-					}
-					,{
+						,hidden: process.platform === 'darwin'
+					},
+					{
+						xtype: 'combo',
+						name: 'window_close_behavior',
+						fieldLabel: 'When closing the main window',
+						labelAlign: 'top',
+						value: config.window_close_behavior,
+						displayField: 'label',
+						valueField: 'value',
+						editable: false,
+						store: Ext.create('Ext.data.Store', {
+							fields: ['value', 'label'],
+							data : [
+								{ 'value': 'keep_in_tray', 'label': 'Keep in tray' },
+								{ 'value': 'keep_in_tray_and_taskbar', 'label': 'Keep in tray and taskbar' },
+								{ 'value': 'quit', 'label': 'Quit' }
+							]
+						}),
+						hidden: process.platform === 'darwin'
+					},
+					{
 						 xtype: 'checkbox'
 						,name: 'always_on_top'
 						,boxLabel: 'Always on top'

--- a/electron/main.js
+++ b/electron/main.js
@@ -23,10 +23,9 @@ const config = new Config({
 		 always_on_top: false
 		,hide_menu_bar: false
 		,skip_taskbar: true
-		,auto_launch: !isDev
-		// On Linux false because it's uncommon for apps on linux to stay in the taskbar on close
-		,keep_in_taskbar_on_close: process.platform !== 'linux'
-		,start_minimized: false
+		,auto_launch: !isDev,
+		 window_close_behavior: 'keep_in_tray',
+		start_minimized: false
 		,systemtray_indicator: true
 		,master_password: false
 		,disable_gpu: process.platform === 'linux'
@@ -199,11 +198,19 @@ function createWindow () {
 					app.hide();
 					break;
 				case 'linux':
-					config.get('keep_in_taskbar_on_close') ? mainWindow.hide() : app.quit();
-					break;
 				case 'win32':
 				default:
-					config.get('keep_in_taskbar_on_close') ? mainWindow.minimize() : mainWindow.hide();
+					switch (config.get('window_close_behavior')) {
+						case 'keep_in_tray':
+							mainWindow.hide();
+							break;
+						case 'keep_in_tray_and_taskbar':
+							mainWindow.minimize();
+							break;
+						case 'quit':
+							app.quit();
+							break;
+					}
 					break;
 			}
 		}


### PR DESCRIPTION
- removes the "keep_in_taskbar_on_close" option, because it's redudant
- adds the option "window_close_behavior" to control the behavior when closing the main window

solves #369 