### PR TITLE
Tray icon - Some minor changes

### DIFF
--- a/electron/tray.js
+++ b/electron/tray.js
@@ -50,8 +50,12 @@ exports.create = function(win, config) {
 	appIcon = new Tray(iconPath);
 	appIcon.setToolTip('Rambox');
 	appIcon.setContextMenu(contextMenu);
-	appIcon.on('double-click', () => {
-		if ( !win.isVisible() || win.isMinimized() ) config.get('maximized') ? win.maximize() : win.show();
+	appIcon.on('click', () => {
+		if ( !win.isVisible() ) {
+			win.isVisible() ? win.hide() : win.show();
+		} else {
+			win.focus();
+		}
 	});
 };
 


### PR DESCRIPTION
This small change is only for the tray icon. What happens now is that:

1. Window is getting focus
2. Single click instead of double click is being used

I am by no means a developer. So the code might be wrong. However I tested it quickly on windows 10 and it works quite nicely. :)