### PR TITLE
Introduce better instructions for Ubuntu development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,20 @@ If you're comfortable getting up and running from a `git clone`, this method is 
 4. `npm run sencha:compile`
 5. `npm start`
 
-----------
+#### Compile on Ubuntu:
+
+These instructions were tested with Ubuntu 17.04.
+1. Install dependencies: `sudo apt install nodejs-legacy npm git`
+2. Build and install electron: `sudo npm install electron-prebuilt -g`
+3. Install Sencha Cmd (non-free): https://www.sencha.com/products/extjs/cmd-download/
+4. Clone repository: `git clone https://github.com/saenzramiro/rambox.git`
+5. Install npm dependencies: `npm install`
+6. Configure `env-sample.js` and rename it to `env.js`.
+7. Compile: `npm run sencha:compile`
+8. Start program: `npm start`
+
+
+-------------------
 
 Disclosure
 -------------------


### PR DESCRIPTION
This is a README with proper instructions on how to setup a GNU/Linux development environment in Ubuntu. It takes out some of the legwork in figuring out that requirements include Sencha and electron, as well as how to install them.