### PR TITLE
Fix bug in Global Unread Counter

### DIFF
--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -412,7 +412,7 @@ Ext.define('Rambox.ux.WebView',{
 	,setUnreadCount: function(newUnreadCount) {
 		var me = this;
 
-		if (me.record.get('includeInGlobalUnreadCounter') === true) {
+		if (newUnreadCount === parseInt(newUnreadCount,10) && me.record.get('includeInGlobalUnreadCounter') === true) {
 			Rambox.util.UnreadCounter.setUnreadCountForService(me.record.get('id'), newUnreadCount);
 		} else {
 			Rambox.util.UnreadCounter.clearUnreadCountForService(me.record.get('id'));


### PR DESCRIPTION
When updating the unread counter Rambox presumes it's an integer, but doesn't check. If it's not an integer the global unread counter becomes "NaN" and doesn't recover (and therefore doesn't update). I've added a check here, but possibly the check should be earlier. We still want to deal with a non-integer unread badge (such as "•") so we should allow for non-integer in the badge, but not in the global unread counter (because we cannot add/substract non-integers across services)