### PR TITLE
No need for custom user agent for Wire

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -265,7 +265,6 @@ Ext.define('Rambox.store.ServicesList', {
 			,description: 'HD quality calls, private and group chats with inline photos, music and video. Also available for your phone or tablet.'
 			,url: 'https://app.wire.com/'
 			,type: 'messaging'
-			,userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36'
 		},
 		{
 			 id: 'sync'


### PR DESCRIPTION
I tried Wire as Custom Service without anything and it work perfectly. The current user agent that was configured was set to Chrome 52 and the minimum that we support is [Chrome 53](https://github.com/wireapp/wire-webapp/blob/dev/aws/config.py#L32)

Fixes #762