### PR TITLE
Add snap support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 			]
 		},
 		"snap": {
- 			"confinement": "classic",
+ 			"confinement": "strict",
  			"grade": "stable"
       		},
 		"directories": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 		"linux": {
 			"category": "Office",
 			"target": [
+				"snap",
 				"AppImage",
 				"deb",
 				"rpm",
@@ -76,6 +77,10 @@
 				"tar.gz"
 			]
 		},
+		"snap": {
+ 			"confinement": "classic",
+ 			"grade": "stable"
+      		},
 		"directories": {
 			"buildResources": "resources/installer/",
 			"output": "dist/",


### PR DESCRIPTION
This pull request adds support for building a Rambox [snap package](https://snapcraft.io), which will require an updated Ubuntu 16.04 host/container to build the snap.

[Bug 1489](https://github.com/electron-userland/electron-builder/issues/1489) in `electron-builder` will need to fixed before Rambox is able to open external URLs correctly.

