### PR TITLE
Update titlebar of application to include title of active tab to assist with time tracking programs

### DIFF
--- a/app/view/main/MainController.js
+++ b/app/view/main/MainController.js
@@ -10,10 +10,20 @@ Ext.define('Rambox.view.main.MainController', {
 		// Set Google Analytics event
 		ga_storage._trackPageview('/index.html', 'main');
 
-		if ( newTab.id === 'ramboxTab' || !newTab.record.get('enabled') ) return;
+		if ( newTab.id === 'ramboxTab' ) {
+			document.title = 'Rambox';
+			return;
+		}
+		
+		if (!newTab.record.get('enabled') ) {
+			return;
+		}
 
 		var webview = newTab.down('component').el.dom;
 		if ( webview ) webview.focus();
+
+		// Update the main window so it includes the active tab title.
+		document.title = 'Rambox - ' + newTab.title;
 	}
 
 	,updatePositions: function(tabPanel, tab) {


### PR DESCRIPTION
I use TimeCamp to track my time and each client of mine uses a different message app (or install of Slack).  TimeCamp records the title of the active window to assist me with time tracking.

This patch updates the title of the main window to include the title of the active tab, allowing that data to be recorded.