### PR TITLE
Added electron-context-menu.

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,9 @@ Ext.application({
 
 // auto update logic
 const ipc = require('electron').ipcRenderer;
+
+require('electron-context-menu')();
+
 ipc.on('showAbout', function(event, message) {
 	!Ext.cq1('about') ? Ext.create('Rambox.view.main.About') : '';
 });

--- a/app/package.json
+++ b/app/package.json
@@ -35,6 +35,7 @@
 		"electron-is-dev": "^0.1.2",
 		"mime": "^1.4.0",
 		"rimraf": "2.6.1",
-		"tmp": "0.0.28"
+		"tmp": "0.0.28",
+		"electron-context-menu": "0.9.1"
 	}
 }

--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -229,6 +229,8 @@ Ext.define('Rambox.ux.WebView',{
 
 		var webview = me.down('component').el.dom;
 
+		require('electron-context-menu')({window: webview});
+
 		// Google Analytics Event
 		ga_storage._trackEvent('Services', 'load', me.type, 1, true);
 

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
 		"electron-is-dev": "^0.1.2",
 		"mime": "^1.4.0",
 		"rimraf": "2.6.1",
-		"tmp": "0.0.28"
+		"tmp": "0.0.28",
+		"electron-context-menu": "0.9.1"
 	}
 }


### PR DESCRIPTION
Hiya! I know there's a PR for this already (#297), however it's missing an important piece and is no longer up to date with the base branch. This includes a require on webview initialization to get context menus loaded up in individual services as well as the main Rambox window. I've been using this in my own fork and can confirm it's working as expected. Hope this helps! :)

- This must be initialized once in the app itself, which makes the
  context menu work correctly in the main Rambox window.
- Aside from that, each webview needs to be initialized with
  electron-context-menu as well.
- I'm currently running a custom fork with this functionality added
  and everything works exactly as expected.