### PR TITLE
Fixed FB Pages URL

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -770,7 +770,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,logo: 'messengerpages.png'
 			,name: 'Messenger for Pages'
 			,description: 'Chat with the people of your Facebook Page.'
-			,url: 'https://facebook.com/___/messages/'
+			,url: 'https://facebook.com/___/inbox/'
 			,type: 'messaging'
 			,js_unread: 'function remove(e){var r=document.getElementById(e);return r.parentNode.removeChild(r)}remove("pagelet_bluebar"),remove("pages_manager_top_bar_container");'
 		},


### PR DESCRIPTION
As mentioned in #281, the URL originally implemented was for the legacy version of Facebook pages messenger rather than the latest version. This pull just updates the URL which brings in the new interface, it involves no actual change to the service (name, description, icon, etc).