### PR TITLE
Mysms service fix

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -347,7 +347,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,logo: 'mysms.png'
 			,name: 'mysms'
 			,description: locale['services[34]']
-			,url: 'https://app.mysms.com/#login'
+			,url: 'https://app.mysms.com/'
 			,type: 'messaging'
 			,js_unread: 'function checkUnread(){var e=document.getElementsByClassName("unread"),t=0;for(i=0;i<e.length;i++)t+=parseInt(e[i].firstChild.innerHTML.trim());updateBadge(t)}function updateBadge(e){e>=1?document.title="("+e+") "+originalTitle:document.title=originalTitle}"https://app.mysms.com/#login"===document.baseURI&&(document.getElementsByClassName("innerPanel")[0].rows[0].style.display="none",document.getElementsByClassName("innerPanel")[0].rows[1].cells[0].firstElementChild.style.display="none",document.getElementsByClassName("msisdnLoginPanel")[0].style.display="inline");var originalTitle=document.title;setInterval(checkUnread,3000);'
 			,note: 'You have to use this service by signing in with your mobile number.'


### PR DESCRIPTION
Fix #819
I think this issue was closed due to lack of feedback. This problem is still a thing and this small change should fix it.
In my custom service I use only "https://app.mysms.com/" instead of "https://app.mysms.com/#login" which every service restart go to login page instead of main app page.