### PR TITLE
Fix slack service icon position when title empty.

### DIFF
--- a/app/util/IconLoader.js
+++ b/app/util/IconLoader.js
@@ -23,7 +23,7 @@ Ext.define('Rambox.util.IconLoader', {
 						false,
 						function (backgroundImage) {
 							if (backgroundImage) {
-								service.setTitle('<img src="'+service.icon+'" width="" style="background-color: white;border-radius: 50%;position: absolute;margin-left: -12px;margin-top: 17px;width: 12px;">'+service.title);
+								service.setTitle('<img src="'+service.icon+'" width="" style="background-color: white;border-radius: 50%;position: absolute;left: 18px;top: 17px;width: 12px;">'+service.title);
 								service.fireEvent('iconchange', service, backgroundImage, service.icon);
 							}
 						}


### PR DESCRIPTION
Fixes #1209

Use absolute positioning for slack service icon instead of margins to avoid incorrect positions without text content for service title.