### PR TITLE
Make settings secure by default: disallow selfsigned certificates

### DIFF
--- a/app/model/Service.js
+++ b/app/model/Service.js
@@ -56,7 +56,7 @@ Ext.define('Rambox.model.Service', {
 	},{
 		 name: 'trust'
 		,type: 'boolean'
-		,defaultValue: true
+		,defaultValue: false
 	},{
 		 name: 'enabled'
 		,type: 'boolean'

--- a/app/view/add/Add.js
+++ b/app/view/add/Add.js
@@ -191,7 +191,7 @@ Ext.define('Rambox.view.add.Add',{
 										,boxLabel: locale['app.window[19]']
 										,name: 'trust'
 										,hidden: me.record.get('type') !== 'custom'
-										,checked: me.edit ? me.record.get('trust') : true
+										,checked: me.edit ? me.record.get('trust') : false
 										,uncheckedValue: false
 										,inputValue: true
 									}


### PR DESCRIPTION
When setting up new custom services the "Trust invalid authority certificates" flag is enabled by default (I hope I fixed it in the right place). This is a problem because most users will use the default values and will therefore have an insecure setup.
The result can be Man-in-the-Middle or other attacks when using default settings!

Maybe the TOFU approach would be a good trade off: saving the certificate on first use, pinning it (checking that it stays the same) and warning the user on change (allow override)?

If this usability/security trade off is wanted, I'd like to have a warning or some setup process which makes it harder to set this flag by accident.