### PR TITLE
Ignore service name when extracting #unreads from window title

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -273,6 +273,7 @@ function createMasterPasswordWindow() {
 }
 
 function updateBadge(title) {
+	title = title.split(" - ")[0]; //Discard service name if present, could also contain digits
 	var messageCount = title.match(/\d+/g) ? parseInt(title.match(/\d+/g).join("")) : 0;
 
 	tray.setBadge(messageCount, config.get('systemtray_indicator'));


### PR DESCRIPTION
The number of updates for the badge in macOS (and possibly other platforms) was derived from the full window name by extracting all digits in it. The full name when a service is selected is "Rambox (_#unreads_) - _service_name_". As the title includes the name of the currently selected service, the "365" in "Outlook 365" was appended to the correct number this way. Now everything past the " - " in the title (i.e. the service name) is removed before extraction, correcting the value in the badge when Outlook 365 is in focus. Doesn't change anything if the window title doesn't contain " - ".

Closes #1131 
Closes #1029 