### PR TITLE
FastMail improvements

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -750,7 +750,8 @@ Ext.define('Rambox.store.ServicesList', {
 			,description: 'Secure, reliable email hosting for businesses, families and professionals. Premium email with no ads, excellent spam protection and rapid personal support.'
 			,url: 'https://www.fastmail.com/mail/'
 			,type: 'mail'
-			,js_unread: 'setTimeout(function(){O.WindowController.openExternal=function(a){var b=document.createElement("a");b.href=a,b.setAttribute("target","_blank"),b.click()};},3000);'
+			,js_unread: 'function checkUnread(){var e=document.getElementsByClassName("v-FolderSource-badge"),t=0;for(i=0;i<e.length;i++)t+=isNaN(parseInt(e[i].innerHTML.trim())) ? 0 : parseInt(e[i].innerHTML.trim());updateBadge(t)}function updateBadge(e){e>=1?document.title="("+e+")"+originalTitle:document.title=originalTitle}var originalTitle=document.title;setInterval(checkUnread,3000);setTimeout(function(){O.WindowController.openExternal=function(a){var b=document.createElement("a");b.href=a,b.setAttribute("target","_blank"),b.click()};},3000);'
+			,note: 'To enable desktop notifications, you have to go to Settings inside FastMail.'
 		},
 		{
 			 id: 'hibox'


### PR DESCRIPTION
Now takes all folders into account while calculating unreads for FastMail instead of only the selected folder. Same code as for Gitter (except for a class name). Also added a note about desktop notifications (available in Settings -> Mail Preferences).

Note: on page reload, the badge uses the value extracted from the document.title for 1-2 seconds before being overridden by the value across all folders. This might also be the case for other similar services.