### PR TITLE
Linux does not support .ico files for the window icon

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -138,11 +138,16 @@ function handleSquirrelEvent() {
 let mainWindow;
 let isQuitting = false;
 
+let iconPath = __dirname + '/../resources/Icon.ico';
+if (process.platform === 'linux') {
+    iconPath = __dirname + '/../resources/Icon.png';
+}
+
 function createWindow () {
 	// Create the browser window using the state information
 	mainWindow = new BrowserWindow({
 		 title: 'Rambox'
-		,icon: __dirname + '/../resources/Icon.ico'
+		,icon: iconPath
 		,backgroundColor: '#FFF'
 		,x: config.get('x')
 		,y: config.get('y')

--- a/electron/main.js
+++ b/electron/main.js
@@ -138,16 +138,11 @@ function handleSquirrelEvent() {
 let mainWindow;
 let isQuitting = false;
 
-let iconPath = __dirname + '/../resources/Icon.ico';
-if (process.platform === 'linux') {
-    iconPath = __dirname + '/../resources/Icon.png';
-}
-
 function createWindow () {
 	// Create the browser window using the state information
 	mainWindow = new BrowserWindow({
 		 title: 'Rambox'
-		,icon: iconPath
+		,icon: __dirname + '/../resources/Icon.' + (process.platform === 'linux' ? 'png' : 'ico')
 		,backgroundColor: '#FFF'
 		,x: config.get('x')
 		,y: config.get('y')


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/33175101/32133422-b4670b98-bbd7-11e7-9887-b31972769957.png)

I'm using Linux Mint 17.3 (and 18.2) with Cinnamon, and Rambox does not show the correct Icon in the taskbar, instead it uses a 'missing image' placeholder. 

Cinnamon (or maybe Linux in general?) does not support .ico as a window icon. Using a png however works (see attached image for a comparison).