### PR TITLE
Rainloop: fixed unread badge for newer versions

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -531,7 +531,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,description: 'RainLoop Webmail - Simple, modern & fast web-based email client.'
 			,url: '___'
 			,type: 'email'
-			,js_unread: 'function checkUnread(){var a=document.querySelectorAll(".e-item .e-link:not(.hidden) .badge.pull-right.count"),b=0;for(i=0;i<a.length;i++)parseInt(a[i].textContent.trim())%1===0&&(b+=parseInt(a[i].textContent.trim()));updateBadge(b)}function updateBadge(a){a>=1?document.title="("+a+") "+originalTitle:document.title=originalTitle}var originalTitle=document.title;setInterval(checkUnread,1e3);'
+			,js_unread: 'function checkUnread(){var t=document.querySelectorAll(".e-item .e-link:not(.hidden) .badge.pull-right.count"),e=0;for(i=0;i<t.length;i++)parseInt(t[i].textContent.trim())%1==0&&"block"==window.getComputedStyle(t[i]).display&&(count=parseInt(t[i].textContent.trim()),e+=parseInt(t[i].textContent.trim()));updateBadge(e)}function updateBadge(t){document.title=t>=1?"("+t+") "+originalTitle:originalTitle}var originalTitle=document.title;setInterval(checkUnread,1e3);'
 		},
 		{
 			 id: 'amium'


### PR DESCRIPTION
In newer Rainloop versions the folder sidebar is splitted into "system"-folders and "user"-folders_
system folders are virtual folders
user folders are "real" folders and also exist on mail server

In the current version of Rainloop unread mails are counted multiple times.
This pull request fixes this behavior by only calculating the sum of visible badges instead of all badges.