### PR TITLE
Fix GroupMe badge count

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -148,7 +148,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://web.groupme.com/signin'
 			,type: 'messaging'
 			,note: 'To enable desktop notifications, you have to go to Options inside GroupMe. To count unread messages, be sure to be in Chats.'
-			,js_unread: 'function checkUnread(){var a=document.querySelectorAll(".badge-count"),b=0;for(i=0;i<a.length;i++)b+=parseInt(a[i].innerHTML.trim());updateBadge(b)}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
+			,js_unread: 'function checkUnread(){var a=document.querySelectorAll(".badge-count:not(.ng-hide)"),b=0;for(i=0;i<a.length;i++)b+=parseInt(a[i].innerHTML.trim());updateBadge(b)}function updateBadge(a){a>=1?rambox.setUnreadCount(a):rambox.clearUnreadCount()}setInterval(checkUnread,3e3);'
 			,dont_update_unread_from_title: true
 		},
 		{


### PR DESCRIPTION
Previous check was attempting to add ints to NaN which was resulting in NaN. This skips over those elements that don't have a count.

Fixes #448 