### PR TITLE
Add 5 second delay to processRequest internet connection test

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,9 @@
 		xhr.open('HEAD', file + "?rand=" + randomNum, true);
 		xhr.send();
 
-		xhr.addEventListener("readystatechange", processRequest, false);
+		xhr.addEventListener("readystatechange", function() {
+			setTimeout(processRequest, 5000);
+		}, false);
 
 		function processRequest(e) {
 			if (xhr.readyState == 4) {


### PR DESCRIPTION
Adding a 5 second delay after `readystatechange` will prevent macOS from incorrectly triggering an alert when the application is set to startup on login. Fixes  #1255