### PR TITLE
Fixed link for partition:persist

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
 						<h3 class="text-center">
 							No personal information will be saved
 							<br>
-							<small>Sessions will persist using the <a href="http://electron.atom.io/docs/api/web-view-tag/#partition" target="_blank">partition:persist</a> attribute for Webviews. So every time you open Rambox, your sessions will keep alive until you remove the service.<br>Sync feature use Auth0 for Single Sign On &amp; Token Based Authentication and to store the services that user is using (and the configuration for each service like Name, Align, Icon, etc).<br><br>You are always welcome to check the code! ;)</small>
+							<small>Sessions will persist using the <a href="https://electronjs.org/docs/api/webview-tag#partition" target="_blank">partition:persist</a> attribute for Webviews. So every time you open Rambox, your sessions will keep alive until you remove the service.<br>Sync feature use Auth0 for Single Sign On &amp; Token Based Authentication and to store the services that user is using (and the configuration for each service like Name, Align, Icon, etc).<br><br>You are always welcome to check the code! ;)</small>
 						</h3>
 					</div>
 				</div>


### PR DESCRIPTION
The link associated with `partition:persist` in Webviews was dead. Updated to new link.