### PR TITLE
Add statusbar toggling

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,6 +127,14 @@ ipc.on('reloadCurrentService', function(e) {
 	var tab = Ext.cq1('app-main').getActiveTab();
 	if ( tab.id !== 'ramboxTab' ) tab.reloadService();
 });
+// Toggle Status Bar
+ipc.on('toggleStatusBar', function() {
+	var tab = Ext.cq1('app-main').getActiveTab();
+
+	if ( tab.id !== 'ramboxTab' ) {
+		tab.down('statusbar').closed ? tab.setStatusBar(tab.record.get('statusbar')) : tab.closeStatusBar();
+	}
+});
 // Focus the current service when Alt + Tab or click in webviews textfields
 window.addEventListener('focus', function() {
 	if(Ext.cq1("app-main")) Ext.cq1("app-main").getActiveTab().down('component').el.dom.focus();

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -163,6 +163,15 @@ module.exports = function(config) {
 					type: 'separator'
 				},
 				{
+					label: '&Toggle Status Bar',
+					click() {
+						sendAction('toggleStatusBar');
+					}
+				},
+				{
+					type: 'separator'
+				},
+				{
 					role: 'zoomin'
 				},
 				{


### PR DESCRIPTION
This code allows the status bar to be toggled.  Currently there is no way to bring the status bar back without reloading the service, and this adds that functionality.


<img width="849" alt="toggle-status-bar" src="https://user-images.githubusercontent.com/7303748/39103303-a6511594-466f-11e8-968c-eacbb35fdb08.PNG">
