### PR TITLE
Add a preference to change the docking position of the service tab bar.

### DIFF
--- a/app/view/main/Main.js
+++ b/app/view/main/Main.js
@@ -385,5 +385,6 @@ Ext.define('Rambox.view.main.Main', {
 		,add: 'updatePositions'
 		,remove: 'updatePositions'
 		,childmove: 'updatePositions'
+		,beforerender: 'initialize'
 	}
 });

--- a/app/view/main/Main.js
+++ b/app/view/main/Main.js
@@ -385,6 +385,6 @@ Ext.define('Rambox.view.main.Main', {
 		,add: 'updatePositions'
 		,remove: 'updatePositions'
 		,childmove: 'updatePositions'
-		,beforerender: 'initialize'
+		,boxready: 'initialize'
 	}
 });

--- a/app/view/main/MainController.js
+++ b/app/view/main/MainController.js
@@ -8,10 +8,11 @@ Ext.define('Rambox.view.main.MainController', {
 
 		if ( config.left_tabbar === true ) {
 			tabPanel.setTabPosition('left');
-			tabPanel.setTabRotation(0);
 		} else {
 			tabPanel.setTabPosition('top');
 		}
+
+		tabPanel.setTabRotation(0);
 	}
 
 	// Make focus on webview every time the user change tabs, to enable the autofocus in websites

--- a/app/view/main/MainController.js
+++ b/app/view/main/MainController.js
@@ -8,6 +8,15 @@ Ext.define('Rambox.view.main.MainController', {
 
 		tabPanel.setTabPosition(config.tabbar_location);
 		tabPanel.setTabRotation(0);
+
+		let reorderer = tabPanel.plugins.find((plugin) => plugin.ptype == "tabreorderer");
+
+		if ( reorderer !== undefined ) {
+			const names = reorderer.container.getLayout().names;
+			reorderer.dd.dim = names.width;
+			reorderer.dd.startAttr = names.beforeX;
+			reorderer.dd.endAttr = names.afterX;
+		}
 	}
 
 	// Make focus on webview every time the user change tabs, to enable the autofocus in websites

--- a/app/view/main/MainController.js
+++ b/app/view/main/MainController.js
@@ -7,9 +7,10 @@ Ext.define('Rambox.view.main.MainController', {
 		const config = ipc.sendSync('getConfig');
 
 		if ( config.left_tabbar === true ) {
-			const mainView = Ext.cq1('app-main');
-			mainView.setTabPosition('left');
-			mainView.setTabRotation(0);
+			tabPanel.setTabPosition('left');
+			tabPanel.setTabRotation(0);
+		} else {
+			tabPanel.setTabPosition('top');
 		}
 	}
 

--- a/app/view/main/MainController.js
+++ b/app/view/main/MainController.js
@@ -6,12 +6,7 @@ Ext.define('Rambox.view.main.MainController', {
 	,initialize: function( tabPanel ) {
 		const config = ipc.sendSync('getConfig');
 
-		if ( config.left_tabbar === true ) {
-			tabPanel.setTabPosition('left');
-		} else {
-			tabPanel.setTabPosition('top');
-		}
-
+		tabPanel.setTabPosition(config.tabbar_location);
 		tabPanel.setTabRotation(0);
 	}
 

--- a/app/view/main/MainController.js
+++ b/app/view/main/MainController.js
@@ -3,6 +3,16 @@ Ext.define('Rambox.view.main.MainController', {
 
 	,alias: 'controller.main'
 
+	,initialize: function( tabPanel ) {
+		const config = ipc.sendSync('getConfig');
+
+		if ( config.left_tabbar === true ) {
+			const mainView = Ext.cq1('app-main');
+			mainView.setTabPosition('left');
+			mainView.setTabRotation(0);
+		}
+	}
+
 	// Make focus on webview every time the user change tabs, to enable the autofocus in websites
 	,onTabChange: function( tabPanel, newTab, oldTab ) {
 		var me = this;

--- a/app/view/preferences/Preferences.js
+++ b/app/view/preferences/Preferences.js
@@ -152,7 +152,7 @@ Ext.define('Rambox.view.preferences.Preferences',{
 						,fieldLabel: 'Service bar location'
 						,labelAlign: 'left'
 						,width: 380
-						,labelWidth: 105
+						,labelWidth: 180
 						,value: config.tabbar_location
 						,displayField: 'label'
 						,valueField: 'value'

--- a/app/view/preferences/Preferences.js
+++ b/app/view/preferences/Preferences.js
@@ -147,10 +147,25 @@ Ext.define('Rambox.view.preferences.Preferences',{
 						,hidden: process.platform === 'darwin'
 					}
 					,{
-						 xtype: 'checkbox'
-						,name: 'left_tabbar'
-						,boxLabel: 'Vertical service bar'
-						,value: config.left_tabbar
+						 xtype: 'combo'
+						,name: 'tabbar_location'
+						,fieldLabel: 'Service bar location'
+						,labelAlign: 'left'
+						,width: 380
+						,labelWidth: 105
+						,value: config.tabbar_location
+						,displayField: 'label'
+						,valueField: 'value'
+						,editable: false
+						,store: Ext.create('Ext.data.Store', {
+							 fields: ['value', 'label']
+							,data: [
+								 { 'value': 'top', 'label': 'Top' }
+								,{ 'value': 'left', 'label': 'Left' }
+								,{ 'value': 'bottom', 'label': 'Bottom' }
+								,{ 'value': 'right', 'label': 'Right' }
+							]
+						})
 					}
 					,{
 						 xtype: 'combo'

--- a/app/view/preferences/Preferences.js
+++ b/app/view/preferences/Preferences.js
@@ -147,6 +147,12 @@ Ext.define('Rambox.view.preferences.Preferences',{
 						,hidden: process.platform === 'darwin'
 					}
 					,{
+						 xtype: 'checkbox'
+						,name: 'left_tabbar'
+						,boxLabel: 'Vertical service bar'
+						,value: config.left_tabbar
+					}
+					,{
 						 xtype: 'combo'
 						,name: 'default_service'
 						,fieldLabel: 'Default service to display when Rambox starts'

--- a/electron/main.js
+++ b/electron/main.js
@@ -20,7 +20,7 @@ const config = new Config({
 	 defaults: {
 		 always_on_top: false
 		,hide_menu_bar: false
-		,left_tabbar: false
+		,tabbar_location: 'top'
 		,window_display_behavior: 'taskbar_tray'
 		,auto_launch: !isDev
 		,flash_frame: true

--- a/electron/main.js
+++ b/electron/main.js
@@ -318,6 +318,8 @@ ipcMain.on('setConfig', function(event, values) {
 	// systemtray_indicator
 	updateBadge(mainWindow.getTitle());
 
+	mainWindow.webContents.executeJavaScript('(function(a){if(a)a.controller.initialize(a);})(Ext.cq1("app-main"))');
+
 	switch ( values.window_display_behavior ) {
 		case 'show_taskbar':
 			mainWindow.setSkipTaskbar(false);

--- a/electron/main.js
+++ b/electron/main.js
@@ -318,7 +318,7 @@ ipcMain.on('setConfig', function(event, values) {
 	// systemtray_indicator
 	updateBadge(mainWindow.getTitle());
 
-	mainWindow.webContents.executeJavaScript('(function(a){if(a)a.controller.initialize(a);})(Ext.cq1("app-main"))');
+	mainWindow.webContents.executeJavaScript('(function(a){if(a)a.controller.initialize(a)})(Ext.cq1("app-main"))');
 
 	switch ( values.window_display_behavior ) {
 		case 'show_taskbar':

--- a/electron/main.js
+++ b/electron/main.js
@@ -20,6 +20,7 @@ const config = new Config({
 	 defaults: {
 		 always_on_top: false
 		,hide_menu_bar: false
+		,left_tabbar: false
 		,window_display_behavior: 'taskbar_tray'
 		,auto_launch: !isDev
 		,flash_frame: true


### PR DESCRIPTION
By default, the service bar is docked on the top side of the app. Since some people (myself included) like to have the bar docked on a different side (so that it could potentially be vertical rather than horizontal), this PR adds a preference that allows the user to select where the bar will be docked on their screen.

Preferences window:
![screenshot_2018-04-28_19-36-44](https://user-images.githubusercontent.com/2063153/39402695-a16e4ca8-4b1b-11e8-8f80-6dd821dfa726.png)

Example, docked on left:
![screenshot_2018-04-28_19-36-52](https://user-images.githubusercontent.com/2063153/39402694-a15c90d0-4b1b-11e8-859b-0fcc3f135671.png)

Closes #954.