### PR TITLE
Clearing master password field after inserting wrong password

### DIFF
--- a/masterpassword.html
+++ b/masterpassword.html
@@ -17,6 +17,7 @@
 			const { ipcRenderer } = require('electron');
 			if ( !ipcRenderer.sendSync('validateMasterPassword', value) ) {
 				alert('The password is incorrect. Try again...');
+				document.getElementsByTagName("input")[0].value = "";
 			}
 		}
 	}


### PR DESCRIPTION
Master password field should be cleared after inserting the wrong password instead of manually removing it every time. This PR is around this issue [https://github.com/saenzramiro/rambox/issues/1563.](https://github.com/saenzramiro/rambox/issues/1563.)
Fixes #1563 